### PR TITLE
feat: 🔧 add skip param to fetchProblems api

### DIFF
--- a/src/Controllers/fetchProblems.ts
+++ b/src/Controllers/fetchProblems.ts
@@ -2,7 +2,7 @@ import { Response } from 'express';
 import { ProblemSetQuestionListData } from '../types';
 
 const fetchProblems = async (
-  options: { limit: number; tags: string },
+  options: { limit: number; skip: number; tags: string },
   res: Response,
   formatData: (data: ProblemSetQuestionListData) => {},
   query: string
@@ -18,7 +18,7 @@ const fetchProblems = async (
         query: query,
         variables: {
           categorySlug: '',
-          skip: 0,
+          skip: options.skip || 0,
           limit: options.limit || 20, //by default get 20 question
           filters: { tags: options.tags ? options.tags.split(' ') : ' ' }, //filter by tags
         },

--- a/src/leetCode.ts
+++ b/src/leetCode.ts
@@ -114,14 +114,15 @@ export const selectProblem = (req: Request, res: Response) => {
 };
 
 export const problems = (
-  req: Request<{}, {}, {}, { limit: number; tags: string }>,
+  req: Request<{}, {}, {}, { limit: number; skip: number; tags: string }>,
   res: Response
 ) => {
   const limit = req.query.limit;
+  const skip = req.query.skip;
   const tags = req.query.tags;
 
   controllers.fetchProblems(
-    { limit, tags },
+    { limit, skip, tags },
     res,
     formatUtils.formatProblemsData,
     gqlQueries.problemListQuery


### PR DESCRIPTION
## What?

This PR adds the `skip` param to the `/fetchProblems` API. Internally, the `skip` variable was always set to **0**.

### Screenshots

| Before | After |
| ------ | ----- |
| <img alt="image" src="https://github.com/user-attachments/assets/aa496aa9-a369-4dc6-b10f-c4c4b86db609"> | <img alt="image" src="https://github.com/user-attachments/assets/67337027-ec04-4799-bb99-e921f6ecc5b0"> |

## Why?

Enabling a user to provide a `skip` param, enabling cursor control for selecting problems from LeetCode's GraphQL API. In my case, this enables pseudo-random problem selection via a random value as the `skip` param.

