### PR TITLE
feat(mcp): add optional auth cookie injection for authenticated requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ bun.lockb
 coverage/
 .vitest/
 
+# Auth cookies (may contain session secrets)
+leetcode-cookies.json
+
 CLAUDE.md
 .claude/
 .specify/

--- a/README.md
+++ b/README.md
@@ -137,6 +137,40 @@ The build step produces `dist/mcp/index.js`, the entry point used by MCP clients
 
 To run only a subset of tools, append the module name (`users`, `problems`, or `discussions`) as an extra argument or set the `MCP_SERVER_MODE` environment variable.
 
+### Authenticated requests (optional)
+
+By default, the MCP server makes unauthenticated requests to the LeetCode GraphQL API. To access user-specific data (submission history, private problem lists, contest participation, etc.), you can provide session cookies via a JSON file:
+
+1. Create a JSON file with your LeetCode session cookies:
+
+   ```json
+   {
+     "LEETCODE_SESSION": "<your session cookie>",
+     "csrftoken": "<your csrf token>",
+     "cf_clearance": "<your cf_clearance cookie>"
+   }
+   ```
+
+2. Set the `LEETCODE_COOKIES_FILE` environment variable in your MCP client config:
+
+   ```json
+   {
+     "mcpServers": {
+       "leetcode-suite": {
+         "command": "node",
+         "args": ["C:\\path\\to\\alfa-leetcode-api\\dist\\mcp\\index.js"],
+         "env": {
+           "LEETCODE_COOKIES_FILE": "C:\\path\\to\\leetcode-cookies.json"
+         }
+       }
+     }
+   }
+   ```
+
+When the env var is set, the server injects `Cookie` and `x-csrftoken` headers into all GraphQL requests. When unset, it falls back to unauthenticated mode silently.
+
+> **Tip:** You can extract `LEETCODE_SESSION` and `csrftoken` from your browser's developer tools after logging in to leetcode.com. The session cookie typically expires after ~14 days.
+
 ### MCP Inspector
 
 Use the Inspector to debug tools locally:

--- a/README.md
+++ b/README.md
@@ -141,7 +141,16 @@ To run only a subset of tools, append the module name (`users`, `problems`, or `
 
 By default, the MCP server makes unauthenticated requests to the LeetCode GraphQL API. To access user-specific data (submission history, private problem lists, contest participation, etc.), you can provide session cookies via a JSON file:
 
-1. Create a JSON file with your LeetCode session cookies:
+1. Extract your LeetCode session cookies using the included helper script:
+
+   ```bash
+   npx playwright install chromium   # first time only
+   npx ts-node scripts/extract-cookies.ts ./leetcode-cookies.json
+   ```
+
+   This opens a browser window — log in to LeetCode and the script will automatically detect your session and save the cookies. The output file is set to `600` permissions (owner-only read/write).
+
+   Alternatively, create the JSON file manually with cookies from your browser's developer tools:
 
    ```json
    {
@@ -169,7 +178,7 @@ By default, the MCP server makes unauthenticated requests to the LeetCode GraphQ
 
 When the env var is set, the server injects `Cookie` and `x-csrftoken` headers into all GraphQL requests. When unset, it falls back to unauthenticated mode silently.
 
-> **Tip:** You can extract `LEETCODE_SESSION` and `csrftoken` from your browser's developer tools after logging in to leetcode.com. The session cookie typically expires after ~14 days.
+> **Note:** The `LEETCODE_SESSION` cookie typically expires after ~14 days. Re-run the extraction script to refresh it.
 
 ### MCP Inspector
 

--- a/mcp/modules/problemTools.ts
+++ b/mcp/modules/problemTools.ts
@@ -1,13 +1,19 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import {
+  addProblemToFavorite,
   getDailyProblem,
   getDailyProblemLegacy,
   getDailyProblemRaw,
   getOfficialSolution,
+  getProblemNote,
   getProblemSet,
+  getProblemStatus,
   getSelectProblem,
   getSelectProblemRaw,
+  getSubmissionDetails,
+  removeProblemFromFavorite,
+  updateProblemNote,
 } from '../leetCodeService';
 import { runTool } from '../serverUtils';
 import { ToolModule } from '../types';
@@ -91,6 +97,85 @@ export class ProblemToolsModule implements ToolModule {
         description: 'Retrieves the legacy daily challenge payload',
       },
       async () => runTool(() => getDailyProblemLegacy()),
+    );
+
+    // ── Auth-required tools ───────────────────────────────────────────
+
+    server.registerTool(
+      'leetcode_submission_details',
+      {
+        title: 'Submission Details',
+        description: '[Auth Required] Full submission: source code, runtime, memory, percentiles, errors',
+        inputSchema: {
+          submissionId: z.number().int().positive(),
+        },
+      },
+      async ({ submissionId }) => runTool(() => getSubmissionDetails({ submissionId })),
+    );
+
+    server.registerTool(
+      'leetcode_problem_note',
+      {
+        title: 'Problem Note',
+        description: "[Auth Required] User's personal note on a problem",
+        inputSchema: {
+          titleSlug: z.string(),
+        },
+      },
+      async ({ titleSlug }) => runTool(() => getProblemNote(titleSlug)),
+    );
+
+    server.registerTool(
+      'leetcode_problem_note_update',
+      {
+        title: 'Update Problem Note',
+        description: '[Auth Required] Create/update personal note on a problem',
+        inputSchema: {
+          titleSlug: z.string(),
+          note: z.string(),
+        },
+      },
+      async ({ titleSlug, note }) => runTool(() => updateProblemNote({ titleSlug, note })),
+    );
+
+    server.registerTool(
+      'leetcode_problem_favorite_add',
+      {
+        title: 'Add to Favorites',
+        description: '[Auth Required] Add problem to a favorites list',
+        inputSchema: {
+          favoriteIdHash: z.string(),
+          questionId: z.string(),
+        },
+      },
+      async ({ favoriteIdHash, questionId }) =>
+        runTool(() => addProblemToFavorite({ favoriteIdHash, questionId })),
+    );
+
+    server.registerTool(
+      'leetcode_problem_favorite_remove',
+      {
+        title: 'Remove from Favorites',
+        description: '[Auth Required] Remove problem from a favorites list',
+        inputSchema: {
+          favoriteIdHash: z.string(),
+          questionId: z.string(),
+        },
+      },
+      async ({ favoriteIdHash, questionId }) =>
+        runTool(() => removeProblemFromFavorite({ favoriteIdHash, questionId })),
+    );
+
+    server.registerTool(
+      'leetcode_problem_status',
+      {
+        title: 'Problem Status',
+        description: '[Auth Required] Solve status for a specific problem (ac/notac/null) — lighter than full select',
+        inputSchema: {
+          titleSlug: z.string(),
+        },
+      },
+      async ({ titleSlug }) => runTool(() => getProblemStatus(titleSlug)),
     );
   }
 }

--- a/mcp/modules/userTools.ts
+++ b/mcp/modules/userTools.ts
@@ -13,12 +13,15 @@ import {
   getUserContest,
   getUserContestHistory,
   getUserContestRankingInfo,
+  getUserFavorites,
   getUserProfileAggregate,
   getUserProfileCalendarRaw,
   getUserProfileRaw,
   getUserProfileSummary,
   getUserProgress,
   getUserProgressRaw,
+  getUserStatus,
+  getUserStreak,
 } from '../leetCodeService';
 import { runTool } from '../serverUtils';
 import { ToolModule } from '../types';
@@ -247,6 +250,35 @@ export class UserToolsModule implements ToolModule {
         },
       },
       async ({ username }) => runTool(() => getUserProgressRaw(username)),
+    );
+
+    // ── Auth-required tools ───────────────────────────────────────────
+
+    server.registerTool(
+      'leetcode_user_status',
+      {
+        title: 'Authenticated User Status',
+        description: '[Auth Required] Authenticated user info: username, isPremium, checkedInToday, notifications',
+      },
+      async () => runTool(() => getUserStatus()),
+    );
+
+    server.registerTool(
+      'leetcode_user_streak',
+      {
+        title: 'Daily Streak',
+        description: '[Auth Required] Daily streak: currentStreak, daysSkipped, todayCompleted',
+      },
+      async () => runTool(() => getUserStreak()),
+    );
+
+    server.registerTool(
+      'leetcode_user_favorites',
+      {
+        title: 'Favorite Lists',
+        description: "[Auth Required] User's favorite/bookmark problem lists with problem IDs",
+      },
+      async () => runTool(() => getUserFavorites()),
     );
   }
 }

--- a/mcp/serverUtils.ts
+++ b/mcp/serverUtils.ts
@@ -6,6 +6,16 @@ import { GraphQLParams, GraphQLClientError, ToolResponse, ToolExecutor, ToolModu
 const GRAPHQL_ENDPOINT = 'https://leetcode.com/graphql';
 export const SERVER_VERSION = '1.0.0';
 
+// Asserts that auth cookies are configured. Throws a clear error if not.
+export function requireAuth(): void {
+  const auth = loadAuthData();
+  if (!auth.cookie) {
+    throw new Error(
+      'This tool requires authentication. Set LEETCODE_COOKIES_FILE env var with a path to your cookies JSON file.',
+    );
+  }
+}
+
 // Loads auth cookies from LEETCODE_COOKIES_FILE env var.
 function loadAuthData(): { cookie: string; csrftoken: string } {
   const cookieFile = process.env.LEETCODE_COOKIES_FILE;

--- a/mcp/types.ts
+++ b/mcp/types.ts
@@ -77,3 +77,18 @@ export type ToolExecutor = () => Promise<unknown>;
 export interface ToolModule {
   register(server: McpServer): void;
 }
+
+/**
+ * Arguments for submission detail lookups (auth required).
+ */
+export type SubmissionDetailArgs = { submissionId: number };
+
+/**
+ * Arguments for question note operations (auth required).
+ */
+export type QuestionNoteArgs = { titleSlug: string; note?: string };
+
+/**
+ * Arguments for favorite toggle operations (auth required).
+ */
+export type ToggleFavoriteArgs = { favoriteIdHash: string; questionId: string };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "check:fix": "biome check --write . && biome format --write .",
     "mcp": "ts-node mcp/index.ts",
     "mcp:dist": "npm run build && node dist/mcp/index.js",
-    "mcp:inspect": "ts-node mcp/runInspector.ts"
+    "mcp:inspect": "ts-node mcp/runInspector.ts",
+    "extract-cookies": "npx playwright install chromium && ts-node scripts/extract-cookies.ts"
   },
   "keywords": [],
   "author": "alfaarghya",
@@ -51,6 +52,9 @@
     "typescript": "^5.9.3",
     "vite": "^6.0.5",
     "vitest": "^4.0.15"
+  },
+  "optionalDependencies": {
+    "playwright": "^1.52.0"
   },
   "lint-staged": {
     "*.{ts,js}": [

--- a/scripts/extract-cookies.ts
+++ b/scripts/extract-cookies.ts
@@ -1,0 +1,67 @@
+/**
+ * Extracts LeetCode session cookies via browser login.
+ *
+ * Usage:
+ *   npx playwright install chromium   # first time only
+ *   npx ts-node scripts/extract-cookies.ts [output-path]
+ *
+ * Default output: ./leetcode-cookies.json
+ */
+
+import { chromium } from 'playwright';
+import { writeFileSync, chmodSync } from 'fs';
+import { resolve } from 'path';
+
+const LOGIN_URL = 'https://leetcode.com/accounts/login/';
+const COOKIE_NAMES = ['LEETCODE_SESSION', 'csrftoken', 'cf_clearance'];
+const POLL_INTERVAL_MS = 1000;
+const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+async function extractCookies(outputPath: string): Promise<void> {
+  console.log('Launching browser...');
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto(LOGIN_URL);
+  console.log('\n  Log in to LeetCode in the browser window.');
+  console.log('  The script will detect your session automatically.\n');
+
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < TIMEOUT_MS) {
+    const cookies = await context.cookies('https://leetcode.com');
+    const session = cookies.find((c) => c.name === 'LEETCODE_SESSION');
+
+    if (session) {
+      const extracted: Record<string, string> = {};
+      for (const cookie of cookies) {
+        if (COOKIE_NAMES.includes(cookie.name)) {
+          extracted[cookie.name] = cookie.value;
+        }
+      }
+
+      // Add metadata
+      const sessionExpiry = new Date(session.expires * 1000).toISOString();
+      const payload = { ...extracted, expires_at: sessionExpiry };
+
+      const absPath = resolve(outputPath);
+      writeFileSync(absPath, JSON.stringify(payload, null, 2) + '\n');
+      chmodSync(absPath, 0o600);
+
+      console.log(`Cookies saved to ${absPath} (permissions: 600)`);
+      console.log(`Session expires: ${sessionExpiry}`);
+      await browser.close();
+      return;
+    }
+
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  await browser.close();
+  console.error('Timed out waiting for login (5 minutes). No cookies saved.');
+  process.exit(1);
+}
+
+const outputPath = process.argv[2] || './leetcode-cookies.json';
+extractCookies(outputPath);

--- a/src/GQLQueries/favoritesLists.ts
+++ b/src/GQLQueries/favoritesLists.ts
@@ -1,0 +1,19 @@
+export const favoritesListsQuery = `
+    query favoritesLists {
+        favoritesLists {
+            allFavorites {
+                idHash
+                name
+                isPublicFavorite
+                viewCount
+                creator
+                isWatched
+                questions {
+                    questionId
+                    title
+                    titleSlug
+                }
+            }
+        }
+    }
+`;

--- a/src/GQLQueries/index.ts
+++ b/src/GQLQueries/index.ts
@@ -3,16 +3,27 @@ export { default as contestQuery } from './contest';
 export { default as dailyProblemQuery } from './dailyProblem';
 export { discussCommentsQuery } from './discussComments';
 export { discussTopicQuery } from './discussTopic';
+export { favoritesListsQuery } from './favoritesLists';
 export { getUserProfileQuery } from './getUserProfile';
 export { default as languageStatsQuery } from './languageStats';
 export { officialSolutionQuery } from './officialSolution';
 export { default as problemListQuery } from './problemList';
+export { problemStatusQuery } from './problemStatus';
+export { questionNoteQuery } from './questionNote';
 export { default as AcSubmissionQuery } from './recentAcSubmit';
 export { default as submissionQuery } from './recentSubmit';
 export { default as selectProblemQuery } from './selectProblem';
 export { skillStatsQuery } from './skillStats';
+export { streakCounterQuery } from './streakCounter';
+export { submissionDetailsQuery } from './submissionDetails';
+export {
+  addToFavoriteMutation,
+  removeFromFavoriteMutation,
+} from './toggleFavorite';
 export { default as trendingDiscussQuery } from './trendingDiscuss';
+export { updateNoteMutation } from './updateNote';
 export { userContestRankingInfoQuery } from './userContestRanking';
 export { default as userProfileQuery } from './userProfile';
 export { userProfileCalendarQuery } from './userProfileCalendar';
 export { userQuestionProgressQuery } from './userQuestionProgress';
+export { userStatusQuery } from './userStatus';

--- a/src/GQLQueries/problemStatus.ts
+++ b/src/GQLQueries/problemStatus.ts
@@ -1,0 +1,13 @@
+export const problemStatusQuery = `
+    query questionStatus($titleSlug: String!) {
+        question(titleSlug: $titleSlug) {
+            questionId
+            questionFrontendId
+            title
+            titleSlug
+            status
+            difficulty
+            isPaidOnly
+        }
+    }
+`;

--- a/src/GQLQueries/questionNote.ts
+++ b/src/GQLQueries/questionNote.ts
@@ -1,0 +1,11 @@
+export const questionNoteQuery = `
+    query questionNote($titleSlug: String!) {
+        question(titleSlug: $titleSlug) {
+            questionId
+            questionFrontendId
+            title
+            titleSlug
+            note
+        }
+    }
+`;

--- a/src/GQLQueries/streakCounter.ts
+++ b/src/GQLQueries/streakCounter.ts
@@ -1,0 +1,9 @@
+export const streakCounterQuery = `
+    query streakCounter {
+        streakCounter {
+            streakCount
+            daysSkipped
+            currentDayCompleted
+        }
+    }
+`;

--- a/src/GQLQueries/submissionDetails.ts
+++ b/src/GQLQueries/submissionDetails.ts
@@ -1,0 +1,32 @@
+export const submissionDetailsQuery = `
+    query submissionDetails($submissionId: Int!) {
+        submissionDetails(submissionId: $submissionId) {
+            runtime
+            runtimeDisplay
+            runtimePercentile
+            memory
+            memoryDisplay
+            memoryPercentile
+            code
+            timestamp
+            lang {
+                name
+                verboseName
+            }
+            question {
+                questionId
+                titleSlug
+                title
+            }
+            notes
+            topicTags {
+                tagId
+                slug
+                name
+            }
+            runtimeError
+            compileError
+            lastTestcase
+        }
+    }
+`;

--- a/src/GQLQueries/toggleFavorite.ts
+++ b/src/GQLQueries/toggleFavorite.ts
@@ -1,0 +1,15 @@
+export const addToFavoriteMutation = `
+    mutation addQuestionToFavorite($favoriteIdHash: String!, $questionId: String!) {
+        addQuestionToFavorite(favoriteIdHash: $favoriteIdHash, questionId: $questionId) {
+            ok
+        }
+    }
+`;
+
+export const removeFromFavoriteMutation = `
+    mutation removeQuestionFromFavorite($favoriteIdHash: String!, $questionId: String!) {
+        removeQuestionFromFavorite(favoriteIdHash: $favoriteIdHash, questionId: $questionId) {
+            ok
+        }
+    }
+`;

--- a/src/GQLQueries/updateNote.ts
+++ b/src/GQLQueries/updateNote.ts
@@ -1,0 +1,10 @@
+export const updateNoteMutation = `
+    mutation updateNote($titleSlug: String!, $content: String!) {
+        updateNote(titleSlug: $titleSlug, content: $content) {
+            question {
+                questionId
+                note
+            }
+        }
+    }
+`;

--- a/src/GQLQueries/userStatus.ts
+++ b/src/GQLQueries/userStatus.ts
@@ -1,0 +1,18 @@
+export const userStatusQuery = `
+    query globalData {
+        userStatus {
+            userId
+            isSignedIn
+            isPremium
+            isVerified
+            username
+            avatar
+            isAdmin
+            checkedInToday
+            notificationStatus {
+                lastModified
+                numUnread
+            }
+        }
+    }
+`;


### PR DESCRIPTION
## Summary

- Adds optional cookie-based authentication for the MCP server's GraphQL requests
- Reads session cookies from a JSON file specified by the `LEETCODE_COOKIES_FILE` env var
- Injects `Cookie` and `x-csrftoken` headers into all outgoing requests when configured
- Falls back silently to unauthenticated mode when the env var is not set (fully backwards-compatible)
- Includes a Playwright-based cookie extraction script for easy setup
- **Adds 9 new auth-required tools** (37 total) for submissions, notes, streaks, and favorites

## What this unlocks

Authenticated LeetCode API endpoints including:
- User submission history & accepted solutions
- Private problem lists & favorites
- Contest participation & rating data
- User-specific profile details (streak, calendar, etc.)

## New auth-required tools (9)

All tools include `[Auth Required]` prefix in their descriptions and call `requireAuth()` before any API request, giving a clear error when cookies aren't configured.

### User tools (3)

| Tool | Description |
|------|-------------|
| `leetcode_user_status` | Authenticated user info: username, isPremium, checkedInToday, notifications |
| `leetcode_user_streak` | Daily streak: streakCount, daysSkipped, currentDayCompleted |
| `leetcode_user_favorites` | User's favorite/bookmark lists with problem IDs |

### Problem tools (6)

| Tool | Description |
|------|-------------|
| `leetcode_submission_details` | Full submission: source code, runtime, memory, percentiles, errors |
| `leetcode_problem_note` | Read user's personal note on a problem |
| `leetcode_problem_note_update` | Create/update personal note on a problem |
| `leetcode_problem_favorite_add` | Add problem to a favorites list |
| `leetcode_problem_favorite_remove` | Remove problem from a favorites list |
| `leetcode_problem_status` | Solve status for a problem (ac/notac/null) — lighter than full select |

## Changes

| File | Change |
|------|--------|
| `mcp/serverUtils.ts` | Added `loadAuthData()` for cookie injection + `requireAuth()` guard |
| `mcp/types.ts` | Added `SubmissionDetailArgs`, `QuestionNoteArgs`, `ToggleFavoriteArgs` types |
| `mcp/leetCodeService.ts` | Added 9 auth-required service functions |
| `mcp/modules/userTools.ts` | Registered 3 new auth-required user tools |
| `mcp/modules/problemTools.ts` | Registered 6 new auth-required problem tools |
| `src/GQLQueries/index.ts` | Added 8 re-exports for new queries/mutations |
| `src/GQLQueries/*.ts` | 8 new files: submissionDetails, streakCounter, userStatus, questionNote, updateNote, toggleFavorite, favoritesLists, problemStatus |
| `scripts/extract-cookies.ts` | Playwright-based login flow — opens browser, waits for auth, saves cookies |
| `README.md` | Added "Authenticated requests" section |
| `.gitignore` | Added `leetcode-cookies.json` to prevent accidental secret commits |
| `package.json` | Added `playwright` as optional dep + `npm run extract-cookies` script |

## Cookie file format

```json
{
  "LEETCODE_SESSION": "<session cookie>",
  "csrftoken": "<csrf token>",
  "cf_clearance": "<cloudflare clearance cookie>"
}
```

## Test plan

- [x] Verify unauthenticated mode still works (no env var set)
- [x] Verify authenticated mode works with valid cookie file
- [x] Verify graceful fallback when cookie file is missing or malformed
- [x] Verify `x-csrftoken` header is correctly injected
- [x] Verify `scripts/extract-cookies.ts` opens browser and saves cookies on login
- [x] Verify `leetcode-cookies.json` is ignored by git
- [x] All 9 auth-required tools tested against live LeetCode API
- [x] `requireAuth()` guard returns clear error when cookies not configured
- [x] `leetcode_submission_details` returns full source code + runtime/memory percentiles
- [x] `leetcode_problem_note_update` round-trip: write note → read back confirms persistence
- [x] `leetcode_problem_favorite_add` / `remove` both return `{ ok: true }`
- [x] `npm run lint` clean, all 236 existing tests pass (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)