### PR TITLE
Add complete OpenAPI spec and Swagger UI docs for all API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ docker run -p 3000:3000 alfaarghya/alfa-leetcode-api:2.0.3
 | _Skill Stats_                 | `/:username/skill`                   | Get the user's skill stats.                                          | <a href="./public/demo/demo24.png" target="_blank">click here</a> |
 | _Lang Stats_                  | `/:username/language`                | Get the language stats of a user                                     | <a href="./public/demo/demo25.png" target="_blank">click here</a> |
 | _Question Progress_           | `/:username/progress`                | Get your question progress                                           | <a href="./public/demo/demo26.png" target="_blank">click here</a> |
+| _Followers_                   | `/:username/followers`               | Get users who follow the profile.                                    | -                                                                 |
+| _Followings_                  | `/:username/followings`              | Get users the profile is following.                                  | -                                                                 |
 
 ### ❓Questions Details
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ At First, I struggled to find proper documentation for the `leetcode.com/graphql
 https://alfa-leetcode-api.onrender.com/
 ```
 
+## Swagger Docs 📘
+
+- Swagger UI: <a href="https://alfa-leetcode-api.onrender.com/docs" target="_blank">https://alfa-leetcode-api.onrender.com/docs</a>
+- OpenAPI JSON: <a href="https://alfa-leetcode-api.onrender.com/openapi.json" target="_blank">https://alfa-leetcode-api.onrender.com/openapi.json</a>
+
 ## Run with docker 🐳
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1636,7 +1636,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.23.tgz",
       "integrity": "sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4626,7 +4625,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4773,7 +4771,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4842,7 +4839,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4936,7 +4932,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5173,7 +5168,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/Controllers/fetchUserDetails.ts
+++ b/src/Controllers/fetchUserDetails.ts
@@ -5,9 +5,10 @@ const fetchUserDetails = async <T, U>(
   res: Response,
   query: string,
   formatData?: (data: T) => U,
+  endpoint = 'https://leetcode.com/graphql',
 ) => {
   try {
-    const response = await fetch('https://leetcode.com/graphql', {
+    const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -23,10 +24,37 @@ const fetchUserDetails = async <T, U>(
       }),
     });
 
-    const result = await response.json();
+    const responseText = await response.text();
+    let result: { data?: T; errors?: unknown };
+
+    try {
+      result = JSON.parse(responseText) as { data?: T; errors?: unknown };
+    } catch {
+      return res.status(502).json({
+        error: 'Upstream service returned non-JSON response',
+        upstreamStatus: response.status,
+        endpoint,
+      });
+    }
+
+    if (!response.ok) {
+      return res.status(response.status).json({
+        error: 'Upstream service request failed',
+        upstreamStatus: response.status,
+        endpoint,
+        details: result.errors ?? null,
+      });
+    }
 
     if (result.errors) {
       return res.send(result);
+    }
+
+    if (result.data == null) {
+      return res.status(502).json({
+        error: 'Upstream service returned empty payload',
+        endpoint,
+      });
     }
 
     if (formatData == null) {

--- a/src/FormatUtils/userData.ts
+++ b/src/FormatUtils/userData.ts
@@ -1,5 +1,5 @@
 import type { UserContest } from '../schema';
-import type { UserData } from '../types';
+import type { FollowersData, FollowingData, UserData } from '../types';
 
 export const formatUserData = (data: UserData) => ({
   username: data.matchedUser.username,
@@ -82,4 +82,14 @@ export const formatLanguageStats = (data: UserData) => ({
 
 export const formatProgressStats = (data: UserData) => ({
   numAcceptedQuestions: data.userProfileUserQuestionProgressV2,
+});
+
+export const formatFollowersData = (data: FollowersData) => ({
+  count: data.followers.users.length,
+  users: data.followers.users,
+});
+
+export const formatFollowingData = (data: FollowingData) => ({
+  count: data.following.users.length,
+  users: data.following.users,
 });

--- a/src/GQLQueries/followers.ts
+++ b/src/GQLQueries/followers.ts
@@ -1,0 +1,14 @@
+export const followersQuery = `
+  query getFollowers($username: String!) {
+    followers(userSlug: $username) {
+      users {
+        realName
+        userAvatar
+        userSlug
+        aboutMe
+        isFollowingMe
+        isFollowedByMe
+      }
+    }
+  }
+`;

--- a/src/GQLQueries/following.ts
+++ b/src/GQLQueries/following.ts
@@ -1,0 +1,14 @@
+export const followingQuery = `
+  query getFollowing($username: String!) {
+    following(userSlug: $username) {
+      users {
+        realName
+        userAvatar
+        userSlug
+        aboutMe
+        isFollowingMe
+        isFollowedByMe
+      }
+    }
+  }
+`;

--- a/src/GQLQueries/index.ts
+++ b/src/GQLQueries/index.ts
@@ -3,6 +3,8 @@ export { default as contestQuery } from './contest';
 export { default as dailyProblemQuery } from './dailyProblem';
 export { discussCommentsQuery } from './discussComments';
 export { discussTopicQuery } from './discussTopic';
+export { followersQuery } from './followers';
+export { followingQuery } from './following';
 export { getUserProfileQuery } from './getUserProfile';
 export { default as languageStatsQuery } from './languageStats';
 export { officialSolutionQuery } from './officialSolution';

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import apicache from 'apicache';
 import cors from 'cors';
 import express, { type NextFunction, type Response } from 'express';
 import rateLimit from 'express-rate-limit';
+import { openApiSpec, swaggerUiHtml } from './docs/openapi';
 import * as leetcode from './leetCode';
 import type { FetchUserDataRequest } from './types';
 
@@ -90,6 +91,14 @@ app.get('/', (_req, res) => {
       },
     },
   });
+});
+
+app.get('/openapi.json', (_req, res) => {
+  res.json(openApiSpec);
+});
+
+app.get(['/docs', '/docs/'], (_req, res) => {
+  res.type('html').send(swaggerUiHtml);
 });
 
 //get trending Discuss

--- a/src/app.ts
+++ b/src/app.ts
@@ -53,6 +53,8 @@ app.get('/', (_req, res) => {
         '/:username/skill': 'Get your skill stats',
         '/:username/language': 'Get your language stats',
         '/:username/progress': 'Get your progress stats',
+        '/:username/followers': 'Get users following this profile',
+        '/:username/followings': 'Get users this profile is following',
       },
       discussion: {
         description: 'Endpoints for fetching discussion topics and comments.',
@@ -154,6 +156,8 @@ app.get('/:username/skill/', leetcode.skillStats);
 app.get('/:username/profile/', leetcode.userProfile);
 app.get('/:username/language', leetcode.languageStats);
 app.get('/:username/progress/', leetcode.progress);
+app.get('/:username/followers', leetcode.followers);
+app.get('/:username/followings', leetcode.followings);
 
 /* ----- Migrated to new routes -> these will be deleted -----*/
 //get user profile calendar

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -1,0 +1,1980 @@
+export const openApiSpec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'Alfa LeetCode API',
+    version: '2.0.3',
+    description:
+      'REST API for LeetCode user profiles, problems, contests, and discussions. This specification is generated from the current Express routes and formatter output.',
+    contact: {
+      name: 'alfa-leetcode-api',
+      url: 'https://github.com/alfaarghya/alfa-leetcode-api',
+    },
+    license: {
+      name: 'MIT',
+      url: 'https://github.com/alfaarghya/alfa-leetcode-api/blob/main/LICENSE',
+    },
+  },
+  servers: [
+    {
+      url: 'https://alfa-leetcode-api.onrender.com/',
+      description: 'Production',
+    },
+  ],
+  tags: [
+    { name: 'Meta', description: 'API metadata and docs endpoints' },
+    { name: 'User', description: 'LeetCode user related endpoints' },
+    { name: 'Problems', description: 'LeetCode problems and solutions' },
+    { name: 'Contests', description: 'LeetCode contests' },
+    { name: 'Discussion', description: 'LeetCode discuss endpoints' },
+    { name: 'Legacy', description: 'Backward-compatible legacy endpoints' },
+  ],
+  paths: {
+    '/': {
+      get: {
+        tags: ['Meta'],
+        summary: 'API overview',
+        description:
+          'Returns a JSON overview of endpoint groups and quick route hints.',
+        operationId: 'getApiOverview',
+        responses: {
+          '200': {
+            description: 'Overview payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ApiOverviewResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/openapi.json': {
+      get: {
+        tags: ['Meta'],
+        summary: 'OpenAPI document',
+        description: 'Returns the full OpenAPI JSON used by Swagger UI.',
+        operationId: 'getOpenApiDocument',
+        responses: {
+          '200': {
+            description: 'OpenAPI JSON document',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  description: 'OpenAPI specification document',
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/docs': {
+      get: {
+        tags: ['Meta'],
+        summary: 'Swagger UI',
+        description: 'Interactive API documentation interface.',
+        operationId: 'getSwaggerUi',
+        responses: {
+          '200': {
+            description: 'Swagger UI page',
+            content: {
+              'text/html': {
+                schema: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/daily': {
+      get: {
+        tags: ['Problems'],
+        summary: 'Get daily problem (formatted)',
+        operationId: 'getDailyProblem',
+        responses: {
+          '200': {
+            description: 'Formatted daily problem payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/DailyProblemResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/daily/raw': {
+      get: {
+        tags: ['Problems'],
+        summary: 'Get daily problem (raw)',
+        operationId: 'getDailyProblemRaw',
+        responses: {
+          '200': {
+            description: 'Raw GraphQL daily challenge payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    activeDailyCodingChallengeQuestion: {
+                      $ref: '#/components/schemas/DailyChallengeQuestion',
+                    },
+                  },
+                  required: ['activeDailyCodingChallengeQuestion'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/select': {
+      get: {
+        tags: ['Problems'],
+        summary: 'Get selected problem (formatted)',
+        operationId: 'getSelectedProblem',
+        parameters: [
+          {
+            name: 'titleSlug',
+            in: 'query',
+            required: true,
+            schema: { type: 'string' },
+            description: 'Problem title slug, e.g. two-sum',
+            example: 'two-sum',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Formatted selected problem payload',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/SelectedProblemResponse',
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Missing titleSlug query parameter',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ValidationErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/select/raw': {
+      get: {
+        tags: ['Problems'],
+        summary: 'Get selected problem (raw)',
+        operationId: 'getSelectedProblemRaw',
+        parameters: [
+          {
+            name: 'titleSlug',
+            in: 'query',
+            required: true,
+            schema: { type: 'string' },
+            description: 'Problem title slug, e.g. two-sum',
+            example: 'two-sum',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Raw GraphQL selected problem payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    question: { $ref: '#/components/schemas/ProblemQuestion' },
+                  },
+                  required: ['question'],
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Missing titleSlug query parameter',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ValidationErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/officialSolution': {
+      get: {
+        tags: ['Problems'],
+        summary: 'Get official solution',
+        operationId: 'getOfficialSolution',
+        parameters: [
+          {
+            name: 'titleSlug',
+            in: 'query',
+            required: true,
+            schema: { type: 'string' },
+            description: 'Problem title slug, e.g. two-sum',
+            example: 'two-sum',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Official solution payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    question: {
+                      type: 'object',
+                      properties: {
+                        solution: {
+                          $ref: '#/components/schemas/OfficialSolution',
+                        },
+                      },
+                      required: ['solution'],
+                    },
+                  },
+                  required: ['question'],
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Missing titleSlug query parameter',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    error: { type: 'string' },
+                  },
+                  required: ['error'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/problems': {
+      get: {
+        tags: ['Problems'],
+        summary: 'List problems',
+        description:
+          'Returns a filtered list of LeetCode problems. Defaults: limit=20 and skip=0. If only skip is provided, limit is forced to 1 by current implementation.',
+        operationId: 'getProblems',
+        parameters: [
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', minimum: 0, default: 20 },
+            description: 'Maximum number of problems to return.',
+          },
+          {
+            name: 'skip',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', minimum: 0, default: 0 },
+            description: 'Number of problems to skip.',
+          },
+          {
+            name: 'tags',
+            in: 'query',
+            required: false,
+            schema: { type: 'string' },
+            description:
+              'Tag filter. Multiple tags can be sent with + or URL-encoded spaces.',
+            example: 'array+math',
+          },
+          {
+            name: 'difficulty',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', enum: ['EASY', 'MEDIUM', 'HARD'] },
+            description: 'Difficulty filter.',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Problem list',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ProblemListResponse' },
+              },
+            },
+          },
+          '400': {
+            description: 'Validation error from upstream GraphQL',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: { type: 'object', additionalProperties: true },
+                },
+              },
+            },
+          },
+          '500': {
+            description: 'Internal server error',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { error: { type: 'string' } },
+                  required: ['error'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/contests': {
+      get: {
+        tags: ['Contests'],
+        summary: 'Get all contests',
+        operationId: 'getAllContests',
+        responses: {
+          '200': {
+            description: 'All contest entries',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    allContests: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Contest' },
+                    },
+                  },
+                  required: ['allContests'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/contests/upcoming': {
+      get: {
+        tags: ['Contests'],
+        summary: 'Get upcoming contests',
+        operationId: 'getUpcomingContests',
+        responses: {
+          '200': {
+            description: 'Only upcoming contests',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    count: { type: 'integer' },
+                    contests: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Contest' },
+                    },
+                  },
+                  required: ['count', 'contests'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/trendingDiscuss': {
+      get: {
+        tags: ['Discussion'],
+        summary: 'Get trending discussions',
+        operationId: 'getTrendingDiscussion',
+        parameters: [
+          {
+            name: 'first',
+            in: 'query',
+            required: true,
+            schema: { type: 'integer', minimum: 0 },
+            description: 'Number of trending topics to fetch.',
+            example: 20,
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Trending discussions payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    cachedTrendingCategoryTopics: {
+                      type: 'array',
+                      items: {
+                        $ref: '#/components/schemas/TrendingCategoryTopic',
+                      },
+                    },
+                  },
+                  required: ['cachedTrendingCategoryTopics'],
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Missing or invalid first parameter',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ValidationErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/discussTopic/{topicId}': {
+      get: {
+        tags: ['Discussion'],
+        summary: 'Get discussion topic',
+        operationId: 'getDiscussionTopic',
+        parameters: [
+          {
+            name: 'topicId',
+            in: 'path',
+            required: true,
+            schema: { type: 'integer' },
+            description: 'Discussion topic id',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Discussion topic payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    topic: { $ref: '#/components/schemas/DiscussTopic' },
+                  },
+                  required: ['topic'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/discussComments/{topicId}': {
+      get: {
+        tags: ['Discussion'],
+        summary: 'Get discussion comments',
+        operationId: 'getDiscussionComments',
+        parameters: [
+          {
+            name: 'topicId',
+            in: 'path',
+            required: true,
+            schema: { type: 'integer' },
+            description: 'Discussion topic id',
+          },
+          {
+            name: 'orderBy',
+            in: 'query',
+            required: false,
+            schema: { type: 'string', default: 'newest_to_oldest' },
+            description: 'Comment order strategy.',
+          },
+          {
+            name: 'pageNo',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', minimum: 1, default: 1 },
+            description: 'Page number.',
+          },
+          {
+            name: 'numPerPage',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', minimum: 1, default: 10 },
+            description: 'Items per page.',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Discussion comments payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    topicComments: {
+                      type: 'object',
+                      properties: {
+                        data: {
+                          type: 'array',
+                          items: {
+                            $ref: '#/components/schemas/DiscussComment',
+                          },
+                        },
+                      },
+                      required: ['data'],
+                    },
+                  },
+                  required: ['topicComments'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}': {
+      get: {
+        tags: ['User'],
+        summary: 'Get user profile summary',
+        operationId: 'getUserSummary',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'User summary profile',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/UserSummaryResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/badges': {
+      get: {
+        tags: ['User'],
+        summary: 'Get user badges',
+        operationId: 'getUserBadges',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'User badges payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/UserBadgesResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/solved': {
+      get: {
+        tags: ['User'],
+        summary: 'Get solved problem statistics',
+        operationId: 'getSolvedStats',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Solved stats payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/SolvedStatsResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/contest': {
+      get: {
+        tags: ['User'],
+        summary: 'Get user contest summary and participation',
+        operationId: 'getUserContest',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Contest summary payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/UserContestResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/contest/history': {
+      get: {
+        tags: ['User'],
+        summary: 'Get full contest history',
+        operationId: 'getUserContestHistory',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Contest history payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ContestHistoryResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/submission': {
+      get: {
+        tags: ['User'],
+        summary: 'Get recent submissions',
+        operationId: 'getRecentSubmissions',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', minimum: 0, default: 20 },
+            description: 'Maximum number of items. Default is 20.',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Recent submission payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/SubmissionListResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/acSubmission': {
+      get: {
+        tags: ['User'],
+        summary: 'Get recent accepted submissions',
+        operationId: 'getRecentAcceptedSubmissions',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'limit',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', minimum: 0, default: 20 },
+            description: 'Maximum number of items. Default is 20.',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Recent accepted submission payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/SubmissionListResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/calendar': {
+      get: {
+        tags: ['User'],
+        summary: 'Get submission calendar',
+        operationId: 'getUserCalendar',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+          {
+            name: 'year',
+            in: 'query',
+            required: false,
+            schema: { type: 'integer', minimum: 0, default: 0 },
+            description:
+              'Calendar year. Default 0 (current behavior fallback).',
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Calendar payload',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/SubmissionCalendarResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/skill': {
+      get: {
+        tags: ['User'],
+        summary: 'Get user skill stats',
+        operationId: 'getUserSkillStats',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Skill stats payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/SkillStatsResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/profile': {
+      get: {
+        tags: ['User'],
+        summary: 'Get full profile in one request',
+        operationId: 'getFullUserProfile',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Combined profile payload',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/FullUserProfileResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/language': {
+      get: {
+        tags: ['User'],
+        summary: 'Get language stats',
+        operationId: 'getUserLanguageStats',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Language stats payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/LanguageStatsResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/progress': {
+      get: {
+        tags: ['User'],
+        summary: 'Get question progress stats',
+        operationId: 'getUserProgressStats',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Question progress payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/ProgressStatsResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/userProfile/{id}': {
+      get: {
+        tags: ['Legacy'],
+        summary: 'Legacy full profile endpoint',
+        description: 'Deprecated route maintained for backward compatibility.',
+        deprecated: true,
+        operationId: 'legacyUserProfileById',
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Combined profile payload',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/FullUserProfileResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/dailyQuestion': {
+      get: {
+        tags: ['Legacy'],
+        summary: 'Legacy daily question endpoint',
+        description: 'Deprecated route maintained for backward compatibility.',
+        deprecated: true,
+        operationId: 'legacyDailyQuestion',
+        responses: {
+          '200': {
+            description: 'Raw GraphQL daily challenge payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    activeDailyCodingChallengeQuestion: {
+                      $ref: '#/components/schemas/DailyChallengeQuestion',
+                    },
+                  },
+                  required: ['activeDailyCodingChallengeQuestion'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/skillStats/{username}': {
+      get: {
+        tags: ['Legacy'],
+        summary: 'Legacy skill stats endpoint',
+        description: 'Deprecated route maintained for backward compatibility.',
+        deprecated: true,
+        operationId: 'legacySkillStats',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Raw GraphQL skill payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    matchedUser: {
+                      type: 'object',
+                      properties: {
+                        tagProblemCounts: {
+                          type: 'object',
+                          additionalProperties: true,
+                        },
+                      },
+                    },
+                  },
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/userProfileUserQuestionProgressV2/{userSlug}': {
+      get: {
+        tags: ['Legacy'],
+        summary: 'Legacy progress endpoint',
+        description: 'Deprecated route maintained for backward compatibility.',
+        deprecated: true,
+        operationId: 'legacyUserProgress',
+        parameters: [
+          {
+            name: 'userSlug',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Raw GraphQL progress payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    userProfileUserQuestionProgressV2: {
+                      type: 'object',
+                      additionalProperties: true,
+                    },
+                  },
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/languageStats': {
+      get: {
+        tags: ['Legacy'],
+        summary: 'Legacy language stats endpoint',
+        description: 'Deprecated route maintained for backward compatibility.',
+        deprecated: true,
+        operationId: 'legacyLanguageStats',
+        parameters: [
+          {
+            name: 'username',
+            in: 'query',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Raw GraphQL language stats payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    matchedUser: {
+                      type: 'object',
+                      properties: {
+                        languageProblemCount: {
+                          type: 'array',
+                          items: {
+                            $ref: '#/components/schemas/LanguageProblemCount',
+                          },
+                        },
+                      },
+                    },
+                  },
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+          '400': {
+            description: 'Missing username parameter',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/ValidationErrorResponse',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/userContestRankingInfo/{username}': {
+      get: {
+        tags: ['Legacy'],
+        summary: 'Legacy user contest ranking endpoint',
+        description: 'Deprecated route maintained for backward compatibility.',
+        deprecated: true,
+        operationId: 'legacyContestRankingInfo',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Raw GraphQL contest ranking payload',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  additionalProperties: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      ApiOverviewResponse: {
+        type: 'object',
+        properties: {
+          apiOverview: { type: 'string' },
+          apiEndpointsLink: { type: 'string', format: 'uri' },
+          routes: {
+            type: 'object',
+            additionalProperties: true,
+          },
+        },
+        required: ['apiOverview', 'apiEndpointsLink', 'routes'],
+      },
+      ValidationErrorResponse: {
+        type: 'object',
+        properties: {
+          error: { type: 'string' },
+          solution: { type: 'string' },
+          example: { type: 'string' },
+        },
+        required: ['error'],
+      },
+      Badge: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          icon: { type: 'string' },
+          id: { type: 'string' },
+          displayName: { type: 'string' },
+          creationDate: { type: 'number' },
+        },
+        additionalProperties: true,
+      },
+      UserSummaryResponse: {
+        type: 'object',
+        properties: {
+          username: { type: 'string' },
+          name: { type: 'string' },
+          birthday: { type: 'string', nullable: true },
+          avatar: { type: 'string' },
+          ranking: { type: 'number' },
+          reputation: { type: 'number' },
+          gitHub: { type: 'string', nullable: true },
+          twitter: { type: 'string', nullable: true },
+          linkedIN: { type: 'string', nullable: true },
+          website: { type: 'array', items: { type: 'string' } },
+          country: { type: 'string', nullable: true },
+          company: { type: 'string', nullable: true },
+          school: { type: 'string', nullable: true },
+          skillTags: { type: 'array', items: { type: 'string' } },
+          about: { type: 'string', nullable: true },
+        },
+        required: ['username', 'name', 'avatar', 'ranking', 'reputation'],
+      },
+      UserBadgesResponse: {
+        type: 'object',
+        properties: {
+          badgesCount: { type: 'integer' },
+          badges: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Badge' },
+          },
+          upcomingBadges: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/Badge' },
+          },
+          activeBadge: { $ref: '#/components/schemas/Badge' },
+        },
+        required: ['badgesCount', 'badges', 'upcomingBadges'],
+      },
+      DifficultyCountItem: {
+        type: 'object',
+        properties: {
+          difficulty: { type: 'string' },
+          count: { type: 'integer' },
+          submissions: { type: 'integer' },
+        },
+        required: ['difficulty', 'count'],
+      },
+      SolvedStatsResponse: {
+        type: 'object',
+        properties: {
+          solvedProblem: { type: 'integer' },
+          easySolved: { type: 'integer' },
+          mediumSolved: { type: 'integer' },
+          hardSolved: { type: 'integer' },
+          totalSubmissionNum: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/DifficultyCountItem' },
+          },
+          acSubmissionNum: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/DifficultyCountItem' },
+          },
+        },
+        required: [
+          'solvedProblem',
+          'easySolved',
+          'mediumSolved',
+          'hardSolved',
+          'totalSubmissionNum',
+          'acSubmissionNum',
+        ],
+      },
+      ContestSummary: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+      ContestHistoryItem: {
+        type: 'object',
+        properties: {
+          attended: { type: 'boolean' },
+          rating: { type: 'number' },
+          ranking: { type: 'number' },
+          trendDirection: { type: 'string' },
+          problemsSolved: { type: 'number' },
+          totalProblems: { type: 'number' },
+          finishTimeInSeconds: { type: 'number' },
+          contest: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              startTime: { type: 'string' },
+            },
+            required: ['title', 'startTime'],
+          },
+        },
+        required: ['attended', 'contest'],
+      },
+      UserContestResponse: {
+        type: 'object',
+        properties: {
+          contestAttend: { type: 'number', nullable: true },
+          contestRating: { type: 'number', nullable: true },
+          contestGlobalRanking: { type: 'number', nullable: true },
+          totalParticipants: { type: 'number', nullable: true },
+          contestTopPercentage: { type: 'number', nullable: true },
+          contestBadges: {
+            oneOf: [
+              { $ref: '#/components/schemas/ContestSummary' },
+              { type: 'null' },
+            ],
+          },
+          contestParticipation: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ContestHistoryItem' },
+          },
+        },
+        required: ['contestParticipation'],
+      },
+      ContestHistoryResponse: {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+          contestHistory: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ContestHistoryItem' },
+          },
+        },
+        required: ['count', 'contestHistory'],
+      },
+      SubmissionItem: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          titleSlug: { type: 'string' },
+          timestamp: { type: 'string' },
+          statusDisplay: { type: 'string' },
+          lang: { type: 'string' },
+        },
+        required: ['title', 'titleSlug', 'timestamp', 'statusDisplay', 'lang'],
+      },
+      SubmissionListResponse: {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+          submission: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/SubmissionItem' },
+          },
+        },
+        required: ['count', 'submission'],
+      },
+      DccBadgeItem: {
+        type: 'object',
+        properties: {
+          timestamp: { type: 'number' },
+          badge: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              icon: { type: 'string' },
+            },
+            required: ['name', 'icon'],
+          },
+        },
+        required: ['timestamp', 'badge'],
+      },
+      SubmissionCalendarResponse: {
+        type: 'object',
+        properties: {
+          activeYears: { type: 'array', items: { type: 'integer' } },
+          streak: { type: 'integer' },
+          totalActiveDays: { type: 'integer' },
+          dccBadges: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/DccBadgeItem' },
+          },
+          submissionCalendar: { type: 'string' },
+        },
+        required: [
+          'activeYears',
+          'streak',
+          'totalActiveDays',
+          'dccBadges',
+          'submissionCalendar',
+        ],
+      },
+      SkillTagItem: {
+        type: 'object',
+        properties: {
+          tagName: { type: 'string' },
+          tagSlug: { type: 'string' },
+          problemsSolved: { type: 'integer' },
+        },
+        required: ['tagName', 'tagSlug', 'problemsSolved'],
+      },
+      SkillStatsResponse: {
+        type: 'object',
+        properties: {
+          fundamental: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/SkillTagItem' },
+          },
+          intermediate: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/SkillTagItem' },
+          },
+          advanced: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/SkillTagItem' },
+          },
+        },
+        required: ['fundamental', 'intermediate', 'advanced'],
+      },
+      LanguageProblemCount: {
+        type: 'object',
+        properties: {
+          languageName: { type: 'string' },
+          problemsSolved: { type: 'integer' },
+        },
+        required: ['languageName', 'problemsSolved'],
+      },
+      LanguageStatsResponse: {
+        type: 'object',
+        properties: {
+          languageProblemCount: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/LanguageProblemCount' },
+          },
+        },
+        required: ['languageProblemCount'],
+      },
+      ProgressDifficultyCount: {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+          difficulty: { type: 'string' },
+        },
+        required: ['count', 'difficulty'],
+      },
+      UserSessionBeatItem: {
+        type: 'object',
+        properties: {
+          difficulty: { type: 'string' },
+          percentage: { type: 'number' },
+        },
+        required: ['difficulty', 'percentage'],
+      },
+      ProgressStatsCore: {
+        type: 'object',
+        properties: {
+          numAcceptedQuestions: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ProgressDifficultyCount' },
+          },
+          numFailedQuestions: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ProgressDifficultyCount' },
+          },
+          numUntouchedQuestions: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ProgressDifficultyCount' },
+          },
+          userSessionBeatsPercentage: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/UserSessionBeatItem' },
+          },
+        },
+        required: [
+          'numAcceptedQuestions',
+          'numFailedQuestions',
+          'numUntouchedQuestions',
+          'userSessionBeatsPercentage',
+        ],
+      },
+      ProgressStatsResponse: {
+        type: 'object',
+        properties: {
+          numAcceptedQuestions: {
+            $ref: '#/components/schemas/ProgressStatsCore',
+          },
+        },
+        required: ['numAcceptedQuestions'],
+      },
+      FullUserProfileResponse: {
+        type: 'object',
+        properties: {
+          totalSolved: { type: 'integer' },
+          totalSubmissions: {
+            oneOf: [
+              {
+                type: 'array',
+                items: { $ref: '#/components/schemas/DifficultyCountItem' },
+              },
+              { type: 'object', additionalProperties: true },
+            ],
+          },
+          totalQuestions: { type: 'integer' },
+          easySolved: { type: 'integer' },
+          totalEasy: { type: 'integer' },
+          mediumSolved: { type: 'integer' },
+          totalMedium: { type: 'integer' },
+          hardSolved: { type: 'integer' },
+          totalHard: { type: 'integer' },
+          ranking: { type: 'number' },
+          contributionPoint: { type: 'number' },
+          reputation: { type: 'number' },
+          submissionCalendar: {
+            type: 'object',
+            additionalProperties: { type: 'integer' },
+          },
+          recentSubmissions: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/SubmissionItem' },
+          },
+          matchedUserStats: {
+            type: 'object',
+            additionalProperties: true,
+          },
+        },
+        required: [
+          'totalSolved',
+          'totalQuestions',
+          'easySolved',
+          'mediumSolved',
+          'hardSolved',
+          'ranking',
+          'reputation',
+          'submissionCalendar',
+          'recentSubmissions',
+        ],
+      },
+      TopicTag: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          slug: { type: 'string' },
+          translatedName: { type: 'string', nullable: true },
+          id: { type: 'string', nullable: true },
+        },
+        required: ['name', 'slug'],
+      },
+      QuestionSolutionSummary: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          canSeeDetail: { type: 'boolean' },
+          paidOnly: { type: 'boolean' },
+          hasVideoSolution: { type: 'boolean' },
+          paidOnlyVideo: { type: 'boolean' },
+        },
+        additionalProperties: true,
+      },
+      ProblemQuestion: {
+        type: 'object',
+        properties: {
+          questionId: { type: 'string' },
+          questionFrontendId: {
+            oneOf: [{ type: 'string' }, { type: 'integer' }],
+          },
+          title: { type: 'string' },
+          titleSlug: { type: 'string' },
+          content: { type: 'string' },
+          difficulty: { type: 'string' },
+          isPaidOnly: { type: 'boolean' },
+          likes: { type: 'integer' },
+          dislikes: { type: 'integer' },
+          similarQuestions: { type: 'string' },
+          exampleTestcases: { type: 'string' },
+          topicTags: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/TopicTag' },
+          },
+          hints: {
+            oneOf: [
+              { type: 'array', items: { type: 'string' } },
+              {
+                type: 'array',
+                items: { type: 'object', additionalProperties: true },
+              },
+            ],
+          },
+          solution: {
+            oneOf: [
+              { $ref: '#/components/schemas/QuestionSolutionSummary' },
+              { type: 'null' },
+            ],
+          },
+          companyTagStats: {
+            oneOf: [
+              { type: 'string' },
+              { type: 'array', items: { type: 'string' } },
+              { type: 'null' },
+            ],
+          },
+        },
+        required: [
+          'questionId',
+          'questionFrontendId',
+          'title',
+          'titleSlug',
+          'content',
+          'difficulty',
+          'isPaidOnly',
+          'likes',
+          'dislikes',
+          'topicTags',
+        ],
+      },
+      DailyChallengeQuestion: {
+        type: 'object',
+        properties: {
+          date: { type: 'string' },
+          link: { type: 'string' },
+          question: { $ref: '#/components/schemas/ProblemQuestion' },
+        },
+        required: ['date', 'link', 'question'],
+      },
+      DailyProblemResponse: {
+        type: 'object',
+        properties: {
+          questionLink: { type: 'string', format: 'uri' },
+          date: { type: 'string' },
+          questionId: { type: 'string' },
+          questionFrontendId: {
+            oneOf: [{ type: 'string' }, { type: 'integer' }],
+          },
+          questionTitle: { type: 'string' },
+          titleSlug: { type: 'string' },
+          difficulty: { type: 'string' },
+          isPaidOnly: { type: 'boolean' },
+          question: { type: 'string' },
+          exampleTestcases: { type: 'string' },
+          topicTags: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/TopicTag' },
+          },
+          hints: {
+            oneOf: [
+              { type: 'array', items: { type: 'string' } },
+              {
+                type: 'array',
+                items: { type: 'object', additionalProperties: true },
+              },
+            ],
+          },
+          solution: {
+            oneOf: [
+              { $ref: '#/components/schemas/QuestionSolutionSummary' },
+              { type: 'null' },
+            ],
+          },
+          companyTagStats: {
+            oneOf: [
+              { type: 'string' },
+              { type: 'array', items: { type: 'string' } },
+              { type: 'null' },
+            ],
+          },
+          likes: { type: 'integer' },
+          dislikes: { type: 'integer' },
+          similarQuestions: { type: 'string' },
+        },
+        required: [
+          'questionLink',
+          'date',
+          'questionId',
+          'questionFrontendId',
+          'questionTitle',
+          'titleSlug',
+          'difficulty',
+          'isPaidOnly',
+          'question',
+          'exampleTestcases',
+          'topicTags',
+          'likes',
+          'dislikes',
+        ],
+      },
+      SelectedProblemResponse: {
+        type: 'object',
+        properties: {
+          link: { type: 'string', format: 'uri' },
+          questionId: { type: 'string' },
+          questionFrontendId: {
+            oneOf: [{ type: 'string' }, { type: 'integer' }],
+          },
+          questionTitle: { type: 'string' },
+          titleSlug: { type: 'string' },
+          difficulty: { type: 'string' },
+          isPaidOnly: { type: 'boolean' },
+          question: { type: 'string' },
+          exampleTestcases: { type: 'string' },
+          topicTags: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/TopicTag' },
+          },
+          hints: {
+            oneOf: [
+              { type: 'array', items: { type: 'string' } },
+              {
+                type: 'array',
+                items: { type: 'object', additionalProperties: true },
+              },
+            ],
+          },
+          solution: {
+            oneOf: [
+              { $ref: '#/components/schemas/QuestionSolutionSummary' },
+              { type: 'null' },
+            ],
+          },
+          companyTagStats: {
+            oneOf: [
+              { type: 'string' },
+              { type: 'array', items: { type: 'string' } },
+              { type: 'null' },
+            ],
+          },
+          likes: { type: 'integer' },
+          dislikes: { type: 'integer' },
+          similarQuestions: { type: 'string' },
+        },
+        required: [
+          'link',
+          'questionId',
+          'questionFrontendId',
+          'questionTitle',
+          'titleSlug',
+          'difficulty',
+          'isPaidOnly',
+          'question',
+          'exampleTestcases',
+          'topicTags',
+          'likes',
+          'dislikes',
+        ],
+      },
+      ProblemListItem: {
+        type: 'object',
+        properties: {
+          acRate: { type: 'number' },
+          difficulty: { type: 'string' },
+          freqBar: { type: 'number', nullable: true },
+          questionFrontendId: {
+            oneOf: [{ type: 'string' }, { type: 'integer' }],
+          },
+          isFavor: { type: 'boolean' },
+          isPaidOnly: { type: 'boolean' },
+          status: { type: 'string', nullable: true },
+          title: { type: 'string' },
+          titleSlug: { type: 'string' },
+          topicTags: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/TopicTag' },
+          },
+          hasSolution: { type: 'boolean' },
+          hasVideoSolution: { type: 'boolean' },
+        },
+        required: [
+          'acRate',
+          'difficulty',
+          'questionFrontendId',
+          'isFavor',
+          'isPaidOnly',
+          'title',
+          'titleSlug',
+          'topicTags',
+          'hasSolution',
+          'hasVideoSolution',
+        ],
+      },
+      ProblemListResponse: {
+        type: 'object',
+        properties: {
+          totalQuestions: { type: 'integer' },
+          count: { type: 'integer' },
+          problemsetQuestionList: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/ProblemListItem' },
+          },
+        },
+        required: ['totalQuestions', 'count', 'problemsetQuestionList'],
+      },
+      Contest: {
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          titleSlug: { type: 'string' },
+          startTime: { type: 'number' },
+          duration: { type: 'number' },
+          originStartTime: { type: 'number' },
+          isVirtual: { type: 'boolean' },
+          containsPremium: { type: 'boolean' },
+        },
+        required: [
+          'title',
+          'titleSlug',
+          'startTime',
+          'duration',
+          'originStartTime',
+          'isVirtual',
+          'containsPremium',
+        ],
+      },
+      DiscussAuthorBadge: {
+        type: 'object',
+        properties: {
+          displayName: { type: 'string' },
+          icon: { type: 'string' },
+        },
+        additionalProperties: true,
+      },
+      DiscussAuthor: {
+        type: 'object',
+        properties: {
+          isDiscussAdmin: { type: 'boolean' },
+          isDiscussStaff: { type: 'boolean' },
+          username: { type: 'string' },
+          nameColor: { type: 'string', nullable: true },
+          activeBadge: {
+            oneOf: [
+              { $ref: '#/components/schemas/DiscussAuthorBadge' },
+              { type: 'null' },
+            ],
+          },
+          profile: {
+            type: 'object',
+            properties: {
+              userAvatar: { type: 'string' },
+              reputation: { type: 'number' },
+            },
+            required: ['userAvatar'],
+          },
+          isActive: { type: 'boolean' },
+        },
+        required: ['username', 'profile'],
+      },
+      CoinReward: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          score: { type: 'number' },
+          description: { type: 'string' },
+          date: { type: 'number' },
+        },
+        additionalProperties: true,
+      },
+      DiscussPost: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          voteCount: { type: 'number' },
+          voteStatus: { type: 'number' },
+          content: { type: 'string' },
+          updationDate: { type: 'number' },
+          creationDate: { type: 'number' },
+          status: { type: 'string' },
+          isHidden: { type: 'boolean' },
+          coinRewards: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/CoinReward' },
+          },
+          author: { $ref: '#/components/schemas/DiscussAuthor' },
+          authorIsModerator: { type: 'boolean' },
+          isOwnPost: { type: 'boolean' },
+        },
+        required: ['id', 'content', 'creationDate', 'author'],
+      },
+      DiscussTopic: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          viewCount: { type: 'number' },
+          topLevelCommentCount: { type: 'number' },
+          subscribed: { type: 'boolean' },
+          title: { type: 'string' },
+          pinned: { type: 'boolean' },
+          tags: { type: 'array', items: { type: 'string' } },
+          hideFromTrending: { type: 'boolean' },
+          post: { $ref: '#/components/schemas/DiscussPost' },
+        },
+        required: ['id', 'title', 'post'],
+      },
+      DiscussComment: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          pinned: { type: 'boolean' },
+          pinnedBy: {
+            type: 'object',
+            properties: {
+              username: { type: 'string' },
+            },
+            additionalProperties: true,
+          },
+          post: { $ref: '#/components/schemas/DiscussPost' },
+          numChildren: { type: 'number' },
+        },
+        required: ['id', 'post', 'numChildren'],
+      },
+      TrendingPostAuthor: {
+        type: 'object',
+        properties: {
+          username: { type: 'string' },
+          isActive: { type: 'boolean' },
+          profile: {
+            type: 'object',
+            properties: {
+              userAvatar: { type: 'string' },
+            },
+            required: ['userAvatar'],
+          },
+        },
+        required: ['username', 'isActive', 'profile'],
+      },
+      TrendingPost: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          creationDate: { type: 'number' },
+          contentPreview: { type: 'string' },
+          author: { $ref: '#/components/schemas/TrendingPostAuthor' },
+        },
+        required: ['id', 'creationDate', 'contentPreview', 'author'],
+      },
+      TrendingCategoryTopic: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' },
+          post: { $ref: '#/components/schemas/TrendingPost' },
+        },
+        required: ['id', 'title', 'post'],
+      },
+      SolutionRating: {
+        type: 'object',
+        properties: {
+          count: { type: 'number' },
+          average: { type: 'number' },
+          userRating: {
+            type: 'object',
+            properties: {
+              score: { type: 'number' },
+            },
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: true,
+      },
+      OfficialSolutionTopicPost: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          status: { type: 'string' },
+          creationDate: { type: 'number' },
+          author: {
+            type: 'object',
+            properties: {
+              username: { type: 'string' },
+              isActive: { type: 'boolean' },
+              profile: {
+                type: 'object',
+                properties: {
+                  userAvatar: { type: 'string' },
+                  reputation: { type: 'number' },
+                },
+                additionalProperties: true,
+              },
+            },
+            additionalProperties: true,
+          },
+        },
+        additionalProperties: true,
+      },
+      OfficialSolutionTopic: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          commentCount: { type: 'number' },
+          topLevelCommentCount: { type: 'number' },
+          viewCount: { type: 'number' },
+          subscribed: { type: 'boolean' },
+          solutionTags: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                slug: { type: 'string' },
+              },
+              required: ['name', 'slug'],
+            },
+          },
+          post: { $ref: '#/components/schemas/OfficialSolutionTopicPost' },
+        },
+        additionalProperties: true,
+      },
+      OfficialSolution: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          title: { type: 'string' },
+          content: { type: 'string' },
+          contentTypeId: { type: 'string' },
+          paidOnly: { type: 'boolean' },
+          hasVideoSolution: { type: 'boolean' },
+          paidOnlyVideo: { type: 'boolean' },
+          canSeeDetail: { type: 'boolean' },
+          rating: { $ref: '#/components/schemas/SolutionRating' },
+          topic: { $ref: '#/components/schemas/OfficialSolutionTopic' },
+        },
+        additionalProperties: true,
+      },
+    },
+  },
+} as const;
+
+export const swaggerUiHtml = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Alfa LeetCode API - Swagger UI</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui.css"
+    />
+    <style>
+      html {
+        box-sizing: border-box;
+      }
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.17.14/swagger-ui-standalone-preset.js"></script>
+    <script>
+      window.ui = SwaggerUIBundle({
+        url: '/openapi.json',
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        docExpansion: 'list',
+        persistAuthorization: false,
+        presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+      });
+    </script>
+  </body>
+</html>
+`;

--- a/src/docs/openapi.ts
+++ b/src/docs/openapi.ts
@@ -16,6 +16,10 @@ export const openApiSpec = {
   },
   servers: [
     {
+      url: 'http://localhost:3000',
+      description: 'Local development',
+    },
+    {
       url: 'https://alfa-leetcode-api.onrender.com/',
       description: 'Production',
     },
@@ -866,6 +870,56 @@ export const openApiSpec = {
         },
       },
     },
+    '/{username}/followers': {
+      get: {
+        tags: ['User'],
+        summary: 'Get followers list',
+        operationId: 'getUserFollowers',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Followers payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/SocialUsersResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/{username}/followings': {
+      get: {
+        tags: ['User'],
+        summary: 'Get following list',
+        operationId: 'getUserFollowings',
+        parameters: [
+          {
+            name: 'username',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Following payload',
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/SocialUsersResponse' },
+              },
+            },
+          },
+        },
+      },
+    },
     '/userProfile/{id}': {
       get: {
         tags: ['Legacy'],
@@ -1401,6 +1455,36 @@ export const openApiSpec = {
           },
         },
         required: ['numAcceptedQuestions'],
+      },
+      SocialUser: {
+        type: 'object',
+        properties: {
+          realName: { type: 'string' },
+          userAvatar: { type: 'string' },
+          userSlug: { type: 'string' },
+          aboutMe: { type: 'string' },
+          isFollowingMe: { type: 'boolean' },
+          isFollowedByMe: { type: 'boolean' },
+        },
+        required: [
+          'realName',
+          'userAvatar',
+          'userSlug',
+          'aboutMe',
+          'isFollowingMe',
+          'isFollowedByMe',
+        ],
+      },
+      SocialUsersResponse: {
+        type: 'object',
+        properties: {
+          count: { type: 'integer' },
+          users: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/SocialUser' },
+          },
+        },
+        required: ['count', 'users'],
       },
       FullUserProfileResponse: {
         type: 'object',

--- a/src/leetCode.ts
+++ b/src/leetCode.ts
@@ -122,6 +122,24 @@ export const progress = (req: Request, res: Response) => {
   );
 };
 
+export const followers = (req: TransformedUserDataRequest, res: Response) => {
+  controllers.fetchUserDetails(
+    req.body,
+    res,
+    gqlQueries.followersQuery,
+    formatUtils.formatFollowersData,
+  );
+};
+
+export const followings = (req: TransformedUserDataRequest, res: Response) => {
+  controllers.fetchUserDetails(
+    req.body,
+    res,
+    gqlQueries.followingQuery,
+    formatUtils.formatFollowingData,
+  );
+};
+
 //Problems Details
 export const dailyProblem = (_req: Request, res: Response) => {
   controllers.fetchSingleProblem(

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,3 +214,24 @@ export interface UserProfileResponse {
   allQuestionsCount: Array<{ count: number }>;
   recentSubmissionList: unknown[];
 }
+
+export interface SocialUser {
+  realName: string;
+  userAvatar: string;
+  userSlug: string;
+  aboutMe: string;
+  isFollowingMe: boolean;
+  isFollowedByMe: boolean;
+}
+
+export interface FollowersData {
+  followers: {
+    users: SocialUser[];
+  };
+}
+
+export interface FollowingData {
+  following: {
+    users: SocialUser[];
+  };
+}

--- a/tests/integration/docs-routes.test.ts
+++ b/tests/integration/docs-routes.test.ts
@@ -1,0 +1,39 @@
+import request from 'supertest';
+import { describe, expect, it } from 'vitest';
+import app from '../../src/app';
+
+describe('Documentation Routes Integration Tests', () => {
+  describe('GET /openapi.json', () => {
+    it('should return OpenAPI JSON document', async () => {
+      const response = await request(app).get('/openapi.json');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/json/);
+      expect(response.body).toHaveProperty('openapi');
+      expect(response.body).toHaveProperty('info');
+      expect(response.body).toHaveProperty('paths');
+      expect(response.body).toHaveProperty('components');
+      expect(response.body.servers[0].url).toBe(
+        'https://alfa-leetcode-api.onrender.com/',
+      );
+    });
+  });
+
+  describe('GET /docs', () => {
+    it('should return Swagger UI html page', async () => {
+      const response = await request(app).get('/docs');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/html/);
+      expect(response.text).toContain('SwaggerUIBundle');
+      expect(response.text).toContain('/openapi.json');
+    });
+
+    it('should support trailing slash', async () => {
+      const response = await request(app).get('/docs/');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['content-type']).toMatch(/html/);
+    });
+  });
+});

--- a/tests/integration/user-routes.test.ts
+++ b/tests/integration/user-routes.test.ts
@@ -254,6 +254,60 @@ describe('User Routes Integration Tests', () => {
     });
   });
 
+  describe('GET /:username/followers', () => {
+    it('should return followers list', async () => {
+      const response = await request(app).get('/testuser/followers');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('count');
+      expect(response.body).toHaveProperty('users');
+      expect(Array.isArray(response.body.users)).toBe(true);
+      expect(response.body.count).toBe(response.body.users.length);
+    });
+
+    it('should return followers with expected fields', async () => {
+      const response = await request(app).get('/testuser/followers');
+
+      expect(response.status).toBe(200);
+      if (response.body.users.length > 0) {
+        const user = response.body.users[0];
+        expect(user).toHaveProperty('realName');
+        expect(user).toHaveProperty('userAvatar');
+        expect(user).toHaveProperty('userSlug');
+        expect(user).toHaveProperty('aboutMe');
+        expect(user).toHaveProperty('isFollowingMe');
+        expect(user).toHaveProperty('isFollowedByMe');
+      }
+    });
+  });
+
+  describe('GET /:username/followings', () => {
+    it('should return following list', async () => {
+      const response = await request(app).get('/testuser/followings');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('count');
+      expect(response.body).toHaveProperty('users');
+      expect(Array.isArray(response.body.users)).toBe(true);
+      expect(response.body.count).toBe(response.body.users.length);
+    });
+
+    it('should return followings with expected fields', async () => {
+      const response = await request(app).get('/testuser/followings');
+
+      expect(response.status).toBe(200);
+      if (response.body.users.length > 0) {
+        const user = response.body.users[0];
+        expect(user).toHaveProperty('realName');
+        expect(user).toHaveProperty('userAvatar');
+        expect(user).toHaveProperty('userSlug');
+        expect(user).toHaveProperty('aboutMe');
+        expect(user).toHaveProperty('isFollowingMe');
+        expect(user).toHaveProperty('isFollowedByMe');
+      }
+    });
+  });
+
   describe('Error handling', () => {
     it('should handle malformed requests gracefully', async () => {
       const response = await request(app).get('/user%20name/profile');

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -4,6 +4,8 @@ import {
   dailyProblem,
   discussComments,
   discussTopic,
+  followers,
+  following,
   languageStats,
   officialSolution,
   problems,
@@ -28,6 +30,8 @@ const queryResponseMap = [
   { identifier: 'selectProblem', response: selectProblem },
   { identifier: 'UserProfileCalendar', response: userCalendar },
   { identifier: 'languageStats', response: languageStats },
+  { identifier: 'getFollowers', response: followers },
+  { identifier: 'getFollowing', response: following },
   { identifier: 'skillStats', response: skillStats },
   {
     identifier: 'userProfileUserQuestionProgressV2',
@@ -42,6 +46,16 @@ const queryResponseMap = [
 
 export const handlers = [
   msw.http.post('https://leetcode.com/graphql', async (ctx) => {
+    const test = await ctx.request.json();
+    const typed = test as { query: string };
+
+    const matchedQuery = queryResponseMap.find((mapping) =>
+      typed.query.includes(mapping.identifier),
+    );
+
+    return msw.HttpResponse.json(matchedQuery?.response ?? {});
+  }),
+  msw.http.post('https://leetcode.com/graphql/noty', async (ctx) => {
     const test = await ctx.request.json();
     const typed = test as { query: string };
 

--- a/tests/msw/mockData/followers.json
+++ b/tests/msw/mockData/followers.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "followers": {
+      "users": [
+        {
+          "realName": "Yash_Chouhan",
+          "userAvatar": "https://assets.leetcode.com/users/default_avatar.jpg",
+          "userSlug": "Yash_Chouhan",
+          "aboutMe": "yee",
+          "isFollowingMe": true,
+          "isFollowedByMe": false
+        },
+        {
+          "realName": "aadesh",
+          "userAvatar": "https://assets.leetcode.com/users/Aadesh_Phadake/avatar_1763877778.png",
+          "userSlug": "Aadesh_Phadake",
+          "aboutMe": "MERN stack developer",
+          "isFollowingMe": true,
+          "isFollowedByMe": true
+        }
+      ]
+    }
+  }
+}

--- a/tests/msw/mockData/following.json
+++ b/tests/msw/mockData/following.json
@@ -1,0 +1,24 @@
+{
+  "data": {
+    "following": {
+      "users": [
+        {
+          "realName": "Shreyaan16",
+          "userAvatar": "https://assets.leetcode.com/users/default_avatar.jpg",
+          "userSlug": "Shreyaan16",
+          "aboutMe": "",
+          "isFollowingMe": false,
+          "isFollowedByMe": true
+        },
+        {
+          "realName": "FlameRunner",
+          "userAvatar": "https://assets.leetcode.com/users/Siddharth_Singh2711/avatar_1770514645.png",
+          "userSlug": "Siddharth_Singh2711",
+          "aboutMe": "Pre Final Year at IIIT Sricity",
+          "isFollowingMe": false,
+          "isFollowedByMe": true
+        }
+      ]
+    }
+  }
+}

--- a/tests/msw/mockData/index.ts
+++ b/tests/msw/mockData/index.ts
@@ -2,6 +2,8 @@ export { default as allContests } from './allContests.json';
 export { default as dailyProblem } from './dailyProblem.json';
 export { default as discussComments } from './discussComments.json';
 export { default as discussTopic } from './discussTopic.json';
+export { default as followers } from './followers.json';
+export { default as following } from './following.json';
 export { default as languageStats } from './languageStats.json';
 export { default as officialSolution } from './officialSolution.json';
 export { default as problems } from './problems.json';


### PR DESCRIPTION
## Overview
This PR expands and improves alfa-leetcode-api in two key areas:

1. API documentation: adds first-class OpenAPI/Swagger support.
2. Feature parity with LeetCode updates: adds user social endpoints for followers/followings.

Together, these changes make the API easier to discover, test, and integrate in both production and local development.

## What changed

### 1. OpenAPI + Swagger documentation
- Added a complete OpenAPI 3.1 specification covering:
  - User endpoints
  - Problem endpoints
  - Contest endpoints
  - Discussion endpoints
  - Meta/documentation endpoints
  - Legacy endpoints (marked as deprecated)
- Added reusable schemas for request parameters and response payloads.
- Added a hosted Swagger UI page served by the API.
- Added an endpoint to serve the OpenAPI JSON document.
- Updated README with documentation links.

### 2. New social user endpoints
- Added:
  - `GET /:username/followers`
  - `GET /:username/followings`
- Integrated query handling + response formatting + route registration for both endpoints.
- Added typings for social user payloads.
- Added integration tests and mock data coverage for the new routes.

### 3. Local testing support in Swagger
- Updated OpenAPI `servers` to support local development testing (`http://localhost:3000`) in Swagger UI, in addition to production.

### 4. Upstream response robustness
- Improved upstream parsing/error handling so non-JSON upstream responses no longer throw raw JSON parse errors.
- API now returns clearer upstream failure messages when LeetCode responds unexpectedly.

## New docs endpoints
- `GET /docs`
- `GET /docs/`
- `GET /openapi.json`

## Implementation details
- OpenAPI includes production server:
  - `https://alfa-leetcode-api.onrender.com/`
- OpenAPI now also includes local server for developer testing:
  - `http://localhost:3000`
- Route docs include parameters, response codes, validation behavior, and schema references.
- Legacy routes remain documented as deprecated for smoother migration.

## Testing performed
- Added integration tests for documentation routes:
  - validates OpenAPI JSON shape from `/openapi.json`
  - validates Swagger HTML from `/docs` and `/docs/`
- Added integration tests for:
  - `/:username/followers`
  - `/:username/followings`
- Updated mock handlers/data for new social GraphQL operations.
- Build check completed successfully.
- New and updated tests pass locally.

## Why this is valuable
- Improves onboarding for contributors with self-serve API docs.
- Reduces ambiguity around request/response contracts.
- Adds support for newly available LeetCode social profile data.
- Improves local development workflow with Swagger local server testing.
- Increases resilience to upstream response format issues.

## Backward compatibility
- No existing endpoint behavior was removed.
- Existing API routes remain intact.
- Legacy endpoints are still available and only documented as deprecated.
- New followers/followings routes are additive.